### PR TITLE
Avoid using the ambiguous \h shorthand character

### DIFF
--- a/Spin.tmLanguage
+++ b/Spin.tmLanguage
@@ -60,13 +60,13 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?i:(%\h*)L)</string>
+			<string>(?i:(%[0-9A-Fa-f]*)L)</string>
 			<key>name</key>
 			<string>constant.numeric.integer.long.hexadecimal.spin</string>
 		</dict>
     <dict>
       <key>match</key>
-      <string>(?i:(\$[\h_]*)|(%[01_]*))</string>
+      <string>(?i:(\$[0-9A-Fa-f_]*)|(%[01_]*))</string>
       <key>name</key>
       <string>constant.numeric.integer.hexadecimal.spin</string>
     </dict>


### PR DESCRIPTION
Depending on the regular expression engine used, \h does not always
mean the same. With a PCRE engine, it matches white spaces, whereas,
with a Oniguruma engine, it matches hexademical digit characters.
Sublime Text uses an Oniguruma engine, but github.com relies on a
PCRE engine.