### PR TITLE
Fix the UUID key

### DIFF
--- a/Spin.tmLanguage
+++ b/Spin.tmLanguage
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>bundleUUID</key>
+	<key>uuid</key>
 	<string>E3BADC20-6B0E-11D9-9DC9-000D93589AF6</string>
 	<key>comment</key>
 	<string>


### PR DESCRIPTION
This looks like a typo or maybe the old name. See the documentation for details: http://docs.sublimetext.info/en/latest/reference/syntaxdefs.html.

This grammar is used on GitHub.com for highlighting and is currently raising errors (see github/linguist#3924 for further details).